### PR TITLE
ssh: fix shell payload string length

### DIFF
--- a/ssh.go
+++ b/ssh.go
@@ -151,7 +151,7 @@ func (s *session) request(ctx context.Context, req *ssh.Request) error {
 		s.env = append(s.env, fmt.Sprintf("%s=%s", r.VariableName, r.VariableValue))
 
 	case "shell":
-		req.Payload = []byte("\x00\x00\x00\x00sh")
+		req.Payload = []byte("\x00\x00\x00\x02sh")
 		fallthrough
 
 	case "exec":


### PR DESCRIPTION
Using ssh.Unmarshal since commit c11ed6a015a8da means the "shell" payload should be propely formatted, with a specified string length. Otherwise, when attempting to connect, you'll see this message in the gokrazy stderr:
ssh: parse error in message type 0

that's because in x/crypto/ssh, the parseString() method expects a length before the string. If length is 0, there will be remaining unparsed data, and an error.