### PR TITLE
Warning for RSA Keys, ssh banner and port options

### DIFF
--- a/breakglass.go
+++ b/breakglass.go
@@ -32,6 +32,10 @@ var (
 		"/perm/breakglass.host_key",
 		"path to a PEM-encoded RSA, DSA or ECDSA private key (create using e.g. ssh-keygen -f /perm/breakglass.host_key -N '' -t rsa)")
 
+	port = flag.String("port",
+		"22",
+		"port for breakglass to listen on")
+
 	forwarding = flag.String("forward",
 		"",
 		"allow port forwarding. Use `loopback` for loopback interfaces and `private-network` for private networks")
@@ -191,7 +195,7 @@ func main() {
 	}
 
 	for _, addr := range addrs {
-		hostport := net.JoinHostPort(addr, "22")
+		hostport := net.JoinHostPort(addr, *port)
 		listener, err := net.Listen("tcp", hostport)
 		if err != nil {
 			log.Fatal(err)

--- a/breakglass.go
+++ b/breakglass.go
@@ -36,6 +36,10 @@ var (
 		"22",
 		"port for breakglass to listen on")
 
+	enableBanner = flag.Bool("enable_banner",
+		false,
+		"Adds a banner to greet the user on login")
+
 	forwarding = flag.String("forward",
 		"",
 		"allow port forwarding. Use `loopback` for loopback interfaces and `private-network` for private networks")
@@ -130,6 +134,20 @@ func main() {
 				return nil, nil
 			}
 			return nil, fmt.Errorf("public key not found in %s", *authorizedKeysPath)
+		},
+		BannerCallback: func(conn ssh.ConnMetadata) string {
+			if !*enableBanner {
+				return ""
+			}
+			bannerMessage := fmt.Sprintf("#\n#  Welcome to gokrazy, %s!\n", conn.User())
+			bannerInfo := fmt.Sprintf("#  This installation is running on a %q!\n#\n", gokrazy.Model())
+			maxChars := len(bannerInfo)
+			if maxChars < len(bannerMessage) {
+				maxChars = len(bannerMessage)
+			}
+			border := strings.Repeat("#", maxChars) + "\n"
+			bannerMessage = border + bannerMessage + bannerInfo + border
+			return bannerMessage
 		},
 	}
 


### PR DESCRIPTION
I started to hack a little on breakglass just for fun today:
- I made the port configurable for my development setup
- I added a warning for ssh-rsa keys in the authorized keys file
  ```
  2022/03/06 23:04:14 breakglass.go:65: Warning: You added a ssh-rsa key to your authorized keys, these do currently not work.
  2022/03/06 23:04:14 breakglass.go:66: Further information: https://github.com/gokrazy/breakglass/issues/11
  2022/03/06 23:04:14 breakglass.go:67: Affected key: ssh-rsa [...] chris@joeryzen (line 3)
  ```
- I added an optional banner to greet the user
  ```
  #########################################################################
  #
  #  Welcome to gokrazy, chris!
  #  This installation is running on a "Raspberry Pi 3 Model B Rev 1.2"!
  #
  #########################################################################
  ```

I do a lot of minor PRs lately, just let me know before you feel spammed 😊 