### PR TITLE
Fix automatically generated hostkey being too short

### DIFF
--- a/breakglass.go
+++ b/breakglass.go
@@ -6,8 +6,8 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/ed25519"
 	"crypto/rand"
-	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
 	"flag"
@@ -91,7 +91,7 @@ func loadHostKey(path string) (ssh.Signer, error) {
 }
 
 func createHostKey(path string) (ssh.Signer, error) {
-	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	_, key, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Modern versions of ssh refuse to connect to a server with a rsa key that
  is less than 2048 and this may change to 3072 or 4096 in the future.
  ed25519 cannot change keysize