### PR TITLE
Fix TERM not being set when a tty is requested

### DIFF
--- a/ssh.go
+++ b/ssh.go
@@ -242,6 +242,9 @@ func (s *session) request(ctx context.Context, req *ssh.Request) error {
 		if err := ssh.Unmarshal(req.Payload, &r); err != nil {
 			return err
 		}
+		if r.TERM != "" {
+			s.env = append(s.env, fmt.Sprintf("TERM=%s", r.TERM))
+		}
 
 		var err error
 		s.ptyf, s.ttyf, err = pty.Open()


### PR DESCRIPTION
Fixes an issue with running some applications that require the TERM variable to be set. tmux, screen, htop etc